### PR TITLE
Fix bug where hiring commands were using main GitHub org instead of test org

### DIFF
--- a/cmd/hiring_send.go
+++ b/cmd/hiring_send.go
@@ -58,7 +58,7 @@ func RunCreateTestRepo(ctx context.Context, candidate string, testRepo string) e
 		return errors.New("failed to get github client")
 	}
 
-	org := cfg.Github.Organization
+	org := cfg.GithubTestOrg.Organization
 	if org == "" {
 		return errors.New("please provide an organization")
 	}

--- a/cmd/hiring_unseat.go
+++ b/cmd/hiring_unseat.go
@@ -58,7 +58,7 @@ func RunUnseat(ctx context.Context, opts *UnseatOpts) error {
 		return errors.New("failed to get github client")
 	}
 
-	org := cfg.Github.Organization
+	org := cfg.GithubTestOrg.Organization
 	if org == "" {
 		return errors.New("please provide an organization")
 	}


### PR DESCRIPTION
Both `hiring` commands were running based on main `[github]` section of the config file.