### PR TITLE
PT-4024 Add option to use Zappr Github app's token for calls to Github

### DIFF
--- a/.github.sample.toml
+++ b/.github.sample.toml
@@ -7,8 +7,8 @@
     # Defines the url for Zappr. Comment it out to load it from ZAPPR_URL environment variable
     URL="https://zappr.domain.com"
 
-    # Defines the Zappr token. Comment it out to load it from ZAPPR_TOKEN environment variable
-    Token=""
+    # Specifies if calls made by Zappr to Github should use its own Client token or yours. Comment it out to load it from ZAPPR_USE_APP_CREDENTIALS environment variable
+    UseZapprGithubCredentials="true"
 
 [github]
     # Defines the github organization

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You will need to fill in the following values to be able to create a repo:
 
 ### Zappr `zappr`
 
-For Zappr you will need a Zappr URL and a Zappr token, the URL is the base URL of your zappr configuration and the token can be found when you login into the UI and copy the value of any request going out the same domain. The cookies that you need are http-only so you can't access them through JS. Just look for a request with the `Cookie:` header and then copy the value.
+For Zappr you will need to specify the URL to Zappr, the URL is the base URL of Zappr, its typically `https://zappr.tools-k8s.hellofresh.io`.
 
 ### GitHub `github`
 

--- a/cmd/repo_delete.go
+++ b/cmd/repo_delete.go
@@ -59,13 +59,7 @@ func RunDeleteRepo(ctx context.Context, name string, opts *DeleteRepoOpts) error
 	}
 
 	var zapprClient zappr.Client
-	if cfg.Zappr.Token == "" {
-		logger.Debug("Authenticating to Zappr using Github token")
-		zapprClient = zappr.NewWithGithubToken(cfg.Zappr.URL, cfg.Github.Token, nil)
-	} else {
-		logger.Debug("Authenticating to Zappr using Zappr token")
-		zapprClient = zappr.NewWithZapprToken(cfg.Zappr.URL, cfg.Zappr.Token, nil)
-	}
+	zapprClient = zappr.New(cfg.Zappr.URL, cfg.Github.Token, nil)
 
 	logger.Debug("Disabling Zappr on repo...")
 	err = zapprClient.Disable(*ghRepo.ID)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,9 +46,14 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	cfg := config.WithContext(ctx)
+
 	if opts.token != "" {
 		cfg.Github.Token = opts.token
 		cfg.GithubTestOrg.Token = opts.token
+	}
+
+	if cfg.Github.Token == "" {
+		log.WithContext(ctx).Fatal("Github token not specified. Please set the GITHUB_TOKEN environment variable, set it in your config file, or provide it with the \"-t\" flag")
 	}
 
 	if opts.org != "" {
@@ -59,7 +64,7 @@ func NewRootCmd() *cobra.Command {
 
 	ctx, err = github.NewContext(ctx, cfg.Github.Token)
 	if err != nil {
-		log.WithContext(ctx).WithError(err).Fatal("Could not create the kube client")
+		log.WithContext(ctx).WithError(err).Fatal("could not create the kube client")
 	}
 
 	// Aggregates Root commands

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,8 +31,8 @@ type (
 
 	// Zappr represents Zappr configurations
 	Zappr struct {
-		URL   string
-		Token string
+		URL                       string
+		UseZapprGithubCredentials bool
 	}
 
 	// Github represents the github configurations
@@ -105,7 +105,8 @@ func NewContext(ctx context.Context, configFile string) (context.Context, error)
 	viper.SetDefault("githubtestorg.token", os.Getenv("GITHUB_TOKEN"))
 
 	viper.SetDefault("zappr.url", os.Getenv("ZAPPR_URL"))
-	viper.SetDefault("zappr.token", os.Getenv("ZAPPR_TOKEN"))
+	viper.SetDefault("zappr.usezapprgithubcredentials", true)
+	viper.BindEnv("ZAPPR_USE_APP_CREDENTIALS", "zappr.usezapprgithubcredentials")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/pkg/zappr/zappr_mock.go
+++ b/pkg/zappr/zappr_mock.go
@@ -9,25 +9,21 @@ import (
 	"github.com/hellofresh/github-cli/pkg/test"
 )
 
-func getDefaultHeader() *http.Header {
+func getDefaultHeader(addContentLength bool) *http.Header {
 	header := &http.Header{}
 	header.Add("User-Agent", "Go-http-client/1.1")
 	header.Add("Accept-Encoding", "gzip")
-	header.Add("Content-Length", "0")
+
+	if addContentLength {
+		header.Add("Content-Length", "0")
+	}
 
 	return header
 }
 
-func getGithubAuthHeader(token string) *http.Header {
-	authHeader := getDefaultHeader()
+func getGithubAuthHeader(token string, addContentLength bool) *http.Header {
+	authHeader := getDefaultHeader(addContentLength)
 	authHeader.Add("Authorization", fmt.Sprintf("token %s", token))
-
-	return authHeader
-}
-
-func getZapprAuthHeader(token string) *http.Header {
-	authHeader := getDefaultHeader()
-	authHeader.Add("Cookie", token)
 
 	return authHeader
 }
@@ -69,7 +65,7 @@ func NewMockAndHandler() (Client, *test.MockHandler, *test.Server) {
 // The internal http client always returns a nil response object.
 func NewMockAndHandlerNilResponse() (Client, *test.MockHandler, *test.Server) {
 	httpClient, mockHandler, mockServer := newMockAndHandlerWithNilResponseTransport()
-	client := NewWithGithubToken("https://fake.zappr/", "1234567890", httpClient)
+	client := New("https://fake.zappr/", "1234567890", httpClient)
 
 	return client, mockHandler, mockServer
 }
@@ -79,17 +75,7 @@ func NewMockAndHandlerNilResponse() (Client, *test.MockHandler, *test.Server) {
 // requests. The caller must close the test server.
 func NewMockAndHandlerWithGithubToken(githubToken string) (Client, *test.MockHandler, *test.Server) {
 	httpClient, mockHandler, mockServer := newMockAndHandler()
-	client := NewWithGithubToken("https://fake.zappr/", githubToken, httpClient)
-
-	return client, mockHandler, mockServer
-}
-
-// NewMockAndHandlerWithZapprToken returns a Zappr Client that uses Zappr Token, Mockhandler, and Server. The client proxies
-// requests to the server and handlers can be registered on the mux to handle
-// requests. The caller must close the test server.
-func NewMockAndHandlerWithZapprToken(zapprToken string) (Client, *test.MockHandler, *test.Server) {
-	httpClient, mockHandler, mockServer := newMockAndHandler()
-	client := NewWithZapprToken("https://fake.zappr/", zapprToken, httpClient)
+	client := New("https://fake.zappr", githubToken, httpClient)
 
 	return client, mockHandler, mockServer
 }


### PR DESCRIPTION
**Background**
API Calls to Zappr can be authorized by passing a Github token. With this approach, all call made by Zappr to Github would also use this token which implies that all github checks setup as part of this process would be tied to the owner of the Github token
Before now, we got the authentication cookie used by Zappr web (UI) to authenticate to the API and used that to also authenticate to Zappr API, this approach ensured that calls made by Zappr to Github uses Zappr's Github app token as expected.

**Now**
An endpoint has been added to Zappr to retrieve the internal Github token that is used to call Github as Zappr.
This PR uses that endpoint to retrieve this Github token and use that for API requests to Zappr